### PR TITLE
Move request pass-through template to file

### DIFF
--- a/scripts/build-serverless
+++ b/scripts/build-serverless
@@ -1,0 +1,40 @@
+#!/usr/bin/env python
+
+import argparse
+import json
+import yaml
+
+
+SERVERLESS_OUT='serverless.yml'
+
+
+def load_passthrough_template(inf):
+    with open(inf, 'r') as passthrough_tpl:
+        return json.load(passthrough_tpl)
+
+
+def load_serverless_template(inf):
+    with open(inf, 'r') as serverless_tpl:
+        return yaml.load(serverless_tpl)
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--serverless_template', '-s', default='serverless.yml.tpl')
+    parser.add_argument('--passthrough_template', '-p', default='templates/passthrough.json')
+    parser.add_argument('--function_name', '-f', default='getTile')
+    cli = parser.parse_args()
+
+    pt_tpl = load_passthrough_template(cli.passthrough_template)
+    serverless_tpl = load_serverless_template(cli.serverless_template)
+
+    func = serverless_tpl['functions'][cli.function_name]
+    func['events'][0]['http']['request']['template']['application/json'] = (
+        '{}'.format(json.dumps(pt_tpl[cli.function_name]))
+    )
+    with open(SERVERLESS_OUT, 'w') as outf:
+        outf.write(yaml.dump(serverless_tpl))
+
+
+if __name__ == '__main__':
+    main()

--- a/scripts/publish
+++ b/scripts/publish
@@ -2,10 +2,26 @@
 
 set -e
 
+while getopts s:p:f: option
+do
+    case "${option}" in
+        s) SERVERLESS_TPL="${OPTARG}";;
+        p) PASSTHROUGH_TPL="${OPTARG}";;
+        f) FUNC_NAME="${OPTARG}";;
+    esac
+done
+
+./scripts/build-serverless -s "${SERVERLESS_TPL}" \
+                           -p "${PASSTHROUGH_TPL}" \
+                           -f "${FUNC_NAME}"
+
 ./sbt clean
 ./sbt assembly
 
 if [ -f .serverless/lambda-geotrellis-tile-server.zip ]; then
     rm .serverless/lambda-geotrellis-tile-server.zip
 fi
+
 serverless deploy
+
+rm serverless.yml

--- a/serverless.yml.tpl
+++ b/serverless.yml.tpl
@@ -31,7 +31,7 @@ functions:
           cors: true
           request:
             template:
-              application/json: '{ "x": "$input.params(''x'')", "y": "$input.params(''y'')", "z": "$input.params(''z'')", "bucket": "$input.params(''b'')", "prefix": "$input.params(''p'')", "layerName": "$input.params(''l'')", "vizType": "$input.params(''v'')" }'
+              application/json: '{ }'
             parameters:
               paths:
                 z: 0

--- a/templates/passthrough.json
+++ b/templates/passthrough.json
@@ -1,0 +1,11 @@
+{
+    "getTile": {
+        "x": "$input.params('x')",
+        "y": "$input.params('y')",
+        "z": "$input.params('z')",
+        "bucket": "$input.params('b')",
+        "prefix": "$input.params('p')",
+        "layerName": "$input.params('l')",
+        "vizType": "$input.params('v')"
+    }
+}

--- a/templates/tile-request.json
+++ b/templates/tile-request.json
@@ -1,5 +1,0 @@
-{
-    "x": "$input.params(''x'')",
-    "y": "$input.params(''y'')",
-    "z": "$input.params(''z'')"
-}


### PR DESCRIPTION
This commit adds some tooling to parse the integration request template from a
file instead of having to include a nuisance json string in the serverless
template itself. This will enable adding future features, like color correction
and assigning particular bands to RGB, without having to include even more
complicated json strings in `serverless.yml`.

One drawback is that something changed where now every time you
`./scripts/publish`, you have to manually change the integration response for
the endpoint back to `Convert to binary (if needed)` again. I'm not sure why
that changed.

Closes #3