### PR TITLE
Improve setup instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,10 +59,16 @@ You'll need the following AWS permissions:
   - cloudformation:*
   - lambda:*
   - apigateway:*
+  - iam:*
+  - logs:*
+  - s3:*
+
+A more minimal set of permissions is possible, but I haven't mapped out the extent of permissions
+requried in each domain. The above will _definitely_ work.
 
 Once that's set up for your user:
 
-- Configure your AWS profile
+- Configure your AWS profile (`aws configure --profile <profile name>`)
 - `npm install -g serverless`
 - `./scripts/publish`
 - Configure your API gateway endpoint from the AWS console:

--- a/scripts/publish
+++ b/scripts/publish
@@ -11,9 +11,9 @@ do
     esac
 done
 
-./scripts/build-serverless -s "${SERVERLESS_TPL}" \
-                           -p "${PASSTHROUGH_TPL}" \
-                           -f "${FUNC_NAME}"
+./scripts/build-serverless -s "${SERVERLESS_TPL:-serverless.yml.tpl}" \
+                           -p "${PASSTHROUGH_TPL:-templates/passthrough.json}" \
+                           -f "${FUNC_NAME:-getTile}"
 
 ./sbt clean
 ./sbt assembly


### PR DESCRIPTION
Overview
-----

This PR documents additional required AWS permissions and defaults arguments for `./scripts/publish`

Testing
-----

- Comment out all the things that actually do anything in `./scripts/publish` and add `echo`s for each of the arguments with its default in this PR
- Verify that those defaults match:
  - the serless template in the root of the repo
  - the location of the passthrough template in `templates/`
  - the name of the function as the top-level key in the `passthrough.json` template

Closes #18 